### PR TITLE
Update ESP8266 FQBN in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,13 +49,13 @@ script:
   # Compile all example sketches included with the library
   # build_sketch arguments: sketch name, fqbn, allow failure, IDE version/list/range
   - build_sketch "${SKETCHBOOK_FOLDER}/libraries/OWBus/examples" "arduino:avr:uno" "false" "oldest" "newest"
-  - build_sketch "${SKETCHBOOK_FOLDER}/libraries/OWBus/examples" "esp8266:esp8266:d1_mini:CpuFrequency=80,UploadSpeed=921600,FlashSize=4M3M" "false" "oldest" "newest"
-  - build_sketch "${SKETCHBOOK_FOLDER}/libraries/OWBus/examples" "esp8266:esp8266:generic:CpuFrequency=80,FlashFreq=40,FlashMode=dio,UploadSpeed=115200,FlashSize=512K64,ResetMethod=ck,Debug=Disabled,DebugLevel=None____" "false" "oldest" "newest"
+  - build_sketch "${SKETCHBOOK_FOLDER}/libraries/OWBus/examples" "esp8266:esp8266:d1_mini:xtal=80,baud=921600,eesz=4M3M" "false" "oldest" "newest"
+  - build_sketch "${SKETCHBOOK_FOLDER}/libraries/OWBus/examples" "esp8266:esp8266:generic:xtal=80,FlashFreq=40,FlashMode=dio,baud=115200,eesz=512K64,ResetMethod=ck,dbg=Disabled,lvl=None____" "false" "oldest" "newest"
 
   # Test with the hourly build of the Arduino IDE to get a warning of any incompatibilities created by recent IDE changes but allow failure because failure may be caused by bugs or changes to the IDE that will be reverted.
   - build_sketch "${SKETCHBOOK_FOLDER}/libraries/OWBus/examples" "arduino:avr:uno" "true" "hourly"
-  - build_sketch "${SKETCHBOOK_FOLDER}/libraries/OWBus/examples" "esp8266:esp8266:d1_mini:CpuFrequency=80,UploadSpeed=921600,FlashSize=4M3M" "true" "hourly"
-  - build_sketch "${SKETCHBOOK_FOLDER}/libraries/OWBus/examples" "esp8266:esp8266:generic:CpuFrequency=80,FlashFreq=40,FlashMode=dio,UploadSpeed=115200,FlashSize=512K64,ResetMethod=ck,Debug=Disabled,DebugLevel=None____" "true" "hourly"
+  - build_sketch "${SKETCHBOOK_FOLDER}/libraries/OWBus/examples" "esp8266:esp8266:d1_mini:xtal=80,baud=921600,eesz=4M3M" "true" "hourly"
+  - build_sketch "${SKETCHBOOK_FOLDER}/libraries/OWBus/examples" "esp8266:esp8266:generic:xtal=80,FlashFreq=40,FlashMode=dio,baud=115200,eesz=512K64,ResetMethod=ck,dbg=Disabled,lvl=None____" "true" "hourly"
 
 #after_script:
   # Print a tab separated report of all sketch verification results to the log


### PR DESCRIPTION
Some of the menu IDs for the ESP8266 boards were recently changed (https://github.com/esp8266/Arduino/issues/5572), which caused compilation in the Travis CI build to fail:
```
Error: CpuFrequency: Invalid option for board "d1_mini"
```

Note the compilations using Arduino IDE 1.6.5-r5 still fail:
```
libraries/OWBus/src/OWBus.h:17:21: fatal error: OneWire.h: No such file or directory
 #include <OneWire.h>
```
but this is due to a different problem. Older IDE versions required `#include` directives in the sketch for all library dependencies. The solution to that error is to add the following line to the example sketches:
```c++
#include <OneWire.h>
```
After fixing that, I still get other errors when compiling with Arduino IDE 1.6.5-r5. I haven't investigated these other errors.

By the way, I'm pleased to see you are using [my CI script](https://github.com/per1234/arduino-ci-script)!